### PR TITLE
ppc64el: enable trusty, xenial, yakkety builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,12 +87,9 @@ matrix:
   - env: VERSION=wheezy/kfreebsd-i386
   allow_failures:
   - env: VERSION=sid/sparc
-  - env: VERSION=trusty/ppc64el
   - env: VERSION=wheezy/s390
   - env: VERSION=wheezy/sparc
-  - env: VERSION=xenial/ppc64el
   - env: VERSION=xenial/s390x
-  - env: VERSION=yakkety/ppc64el
   - env: VERSION=yakkety/s390x
 
 branches:

--- a/trusty/ppc64el/skip
+++ b/trusty/ppc64el/skip
@@ -1,1 +1,0 @@
-https://github.com/vicamo/docker-brew-ubuntu-debootstrap/issues/2

--- a/xenial/ppc64el/skip
+++ b/xenial/ppc64el/skip
@@ -1,1 +1,0 @@
-https://github.com/vicamo/docker-brew-ubuntu-debootstrap/issues/2

--- a/yakkety/ppc64el/skip
+++ b/yakkety/ppc64el/skip
@@ -1,1 +1,0 @@
-https://github.com/vicamo/docker-brew-ubuntu-debootstrap/issues/2


### PR DESCRIPTION
These builds no longer fail with qemu-2.6.