### PR TITLE
Update debian default-libmysqlclient-dev usage

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:SUITE-ARCH-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/jessie/arm64/Dockerfile
+++ b/jessie/arm64/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:jessie-arm64-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/jessie/armel/Dockerfile
+++ b/jessie/armel/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:jessie-armel-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/jessie/armhf/Dockerfile
+++ b/jessie/armhf/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:jessie-armhf-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/jessie/i386/Dockerfile
+++ b/jessie/i386/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:jessie-i386-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/jessie/kfreebsd-amd64/Dockerfile
+++ b/jessie/kfreebsd-amd64/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:jessie-kfreebsd-amd64-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/jessie/kfreebsd-i386/Dockerfile
+++ b/jessie/kfreebsd-i386/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:jessie-kfreebsd-i386-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/jessie/mips/Dockerfile
+++ b/jessie/mips/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:jessie-mips-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/jessie/mipsel/Dockerfile
+++ b/jessie/mipsel/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:jessie-mipsel-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/jessie/powerpc/Dockerfile
+++ b/jessie/powerpc/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:jessie-powerpc-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/jessie/ppc64el/Dockerfile
+++ b/jessie/ppc64el/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:jessie-ppc64el-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/jessie/s390x/Dockerfile
+++ b/jessie/s390x/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:jessie-s390x-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/precise/armhf/Dockerfile
+++ b/precise/armhf/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:precise-armhf-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/precise/i386/Dockerfile
+++ b/precise/i386/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:precise-i386-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/sid/arm64/Dockerfile
+++ b/sid/arm64/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:sid-arm64-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/sid/armel/Dockerfile
+++ b/sid/armel/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:sid-armel-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/sid/armhf/Dockerfile
+++ b/sid/armhf/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:sid-armhf-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/sid/hurd-i386/Dockerfile
+++ b/sid/hurd-i386/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:sid-hurd-i386-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/sid/i386/Dockerfile
+++ b/sid/i386/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:sid-i386-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/sid/kfreebsd-amd64/Dockerfile
+++ b/sid/kfreebsd-amd64/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:sid-kfreebsd-amd64-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/sid/kfreebsd-i386/Dockerfile
+++ b/sid/kfreebsd-i386/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:sid-kfreebsd-i386-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/sid/mips/Dockerfile
+++ b/sid/mips/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:sid-mips-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/sid/mips64el/Dockerfile
+++ b/sid/mips64el/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:sid-mips64el-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/sid/mipsel/Dockerfile
+++ b/sid/mipsel/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:sid-mipsel-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/sid/powerpc/Dockerfile
+++ b/sid/powerpc/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:sid-powerpc-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/sid/ppc64el/Dockerfile
+++ b/sid/ppc64el/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:sid-ppc64el-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/sid/s390x/Dockerfile
+++ b/sid/s390x/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:sid-s390x-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/stretch/arm64/Dockerfile
+++ b/stretch/arm64/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:stretch-arm64-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/stretch/armel/Dockerfile
+++ b/stretch/armel/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:stretch-armel-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/stretch/armhf/Dockerfile
+++ b/stretch/armhf/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:stretch-armhf-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/stretch/i386/Dockerfile
+++ b/stretch/i386/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:stretch-i386-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/stretch/mips/Dockerfile
+++ b/stretch/mips/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:stretch-mips-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/stretch/mips64el/Dockerfile
+++ b/stretch/mips64el/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:stretch-mips64el-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/stretch/mipsel/Dockerfile
+++ b/stretch/mipsel/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:stretch-mipsel-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/stretch/ppc64el/Dockerfile
+++ b/stretch/ppc64el/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:stretch-ppc64el-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/stretch/s390x/Dockerfile
+++ b/stretch/s390x/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:stretch-s390x-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/trusty/arm64/Dockerfile
+++ b/trusty/arm64/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:trusty-arm64-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/trusty/armhf/Dockerfile
+++ b/trusty/armhf/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:trusty-armhf-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/trusty/i386/Dockerfile
+++ b/trusty/i386/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:trusty-i386-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/trusty/ppc64el/Dockerfile
+++ b/trusty/ppc64el/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:trusty-ppc64el-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/wheezy/armel/Dockerfile
+++ b/wheezy/armel/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:wheezy-armel-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/wheezy/armhf/Dockerfile
+++ b/wheezy/armhf/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:wheezy-armhf-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/wheezy/i386/Dockerfile
+++ b/wheezy/i386/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:wheezy-i386-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/wheezy/ia64/Dockerfile
+++ b/wheezy/ia64/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:wheezy-ia64-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/wheezy/kfreebsd-amd64/Dockerfile
+++ b/wheezy/kfreebsd-amd64/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:wheezy-kfreebsd-amd64-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/wheezy/kfreebsd-i386/Dockerfile
+++ b/wheezy/kfreebsd-i386/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:wheezy-kfreebsd-i386-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/wheezy/mips/Dockerfile
+++ b/wheezy/mips/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:wheezy-mips-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/wheezy/mipsel/Dockerfile
+++ b/wheezy/mipsel/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:wheezy-mipsel-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/wheezy/powerpc/Dockerfile
+++ b/wheezy/powerpc/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:wheezy-powerpc-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/wheezy/s390/Dockerfile
+++ b/wheezy/s390/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:wheezy-s390-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/wheezy/s390x/Dockerfile
+++ b/wheezy/s390x/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:wheezy-s390x-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/wheezy/sparc/Dockerfile
+++ b/wheezy/sparc/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:wheezy-sparc-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/xenial/arm64/Dockerfile
+++ b/xenial/arm64/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:xenial-arm64-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/xenial/armhf/Dockerfile
+++ b/xenial/armhf/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:xenial-armhf-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/xenial/i386/Dockerfile
+++ b/xenial/i386/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:xenial-i386-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/xenial/ppc64el/Dockerfile
+++ b/xenial/ppc64el/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:xenial-ppc64el-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/xenial/s390x/Dockerfile
+++ b/xenial/s390x/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:xenial-s390x-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/yakkety/arm64/Dockerfile
+++ b/yakkety/arm64/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:yakkety-arm64-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/yakkety/armhf/Dockerfile
+++ b/yakkety/armhf/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:yakkety-armhf-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/yakkety/i386/Dockerfile
+++ b/yakkety/i386/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:yakkety-i386-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/yakkety/ppc64el/Dockerfile
+++ b/yakkety/ppc64el/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:yakkety-ppc64el-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/yakkety/s390x/Dockerfile
+++ b/yakkety/s390x/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:yakkety-s390x-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/zesty/arm64/Dockerfile
+++ b/zesty/arm64/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:zesty-arm64-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/zesty/armhf/Dockerfile
+++ b/zesty/armhf/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:zesty-armhf-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/zesty/i386/Dockerfile
+++ b/zesty/i386/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:zesty-i386-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/zesty/ppc64el/Dockerfile
+++ b/zesty/ppc64el/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:zesty-ppc64el-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*

--- a/zesty/s390x/Dockerfile
+++ b/zesty/s390x/Dockerfile
@@ -1,8 +1,9 @@
 # GENERATED FROM Dockerfile.template
 FROM vicamo/buildpack-deps:zesty-s390x-scm
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		autoconf \
 		automake \
 		bzip2 \
@@ -24,7 +25,6 @@ RUN apt-get update \
 		liblzma-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
-		libmysqlclient-dev \
 		libncurses-dev \
 		libpng-dev \
 		libpq-dev \
@@ -40,5 +40,15 @@ RUN apt-get update \
 		patch \
 		xz-utils \
 		zlib1g-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*_dists_*
+		\
+# https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
+		$( \
+# if we use just "apt-cache show" here, it returns zero because "Can't select versions from package 'libmysqlclient-dev' as it is purely virtual", hence the pipe to grep
+			if apt-cache show 'default-libmysqlclient-dev' 2>/dev/null | grep -q '^Version:'; then \
+				echo 'default-libmysqlclient-dev'; \
+			else \
+				echo 'libmysqlclient-dev'; \
+			fi \
+		) \
+	; \
+	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Debian now moves to default-libmysqlclient-dev metapackage on sid and
stretch.

See: http://mrpogson.com/2016/12/09/debian-default-moves-to-mariadb/